### PR TITLE
Lx gr surveys add org tab

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -12,8 +12,9 @@ import {
   PersonInfo,
   ResponseInfo,
   SurveyTemplate,
+  SurveyTemplateData,
   surveyTemplateSchema,
-  SurveyTemplateData
+  surveyTemplatesSchema,
 } from './dtos/survey-assignment.dto';
 import User from './dtos/user.dto';
 
@@ -119,7 +120,7 @@ export class ApiClient {
 
   public async getMySurveyTemplates(): Promise<SurveyTemplateData[]> {
     const surveytemplates = await this.get('/survey-template');
-    return surveyTemplateSchema.parse(surveytemplates) as SurveyTemplateData[];
+    return surveyTemplatesSchema.parse(surveytemplates) as SurveyTemplateData[];
   }
 
   public async completeAssignment(assignmentUuid: string, responses: Response[]): Promise<void> {

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -12,7 +12,8 @@ import {
   PersonInfo,
   ResponseInfo,
   SurveyTemplate,
-  SurveyTemplateData,
+  surveyTemplateSchema,
+  SurveyTemplateData
 } from './dtos/survey-assignment.dto';
 import User from './dtos/user.dto';
 
@@ -118,7 +119,7 @@ export class ApiClient {
 
   public async getMySurveyTemplates(): Promise<SurveyTemplateData[]> {
     const surveytemplates = await this.get('/survey-template');
-    return surveytemplates as Promise<SurveyTemplateData[]>;
+    return surveyTemplateSchema.parse(surveytemplates) as SurveyTemplateData[];
   }
 
   public async completeAssignment(assignmentUuid: string, responses: Response[]): Promise<void> {

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -11,6 +11,8 @@ import {
   Youth,
   PersonInfo,
   ResponseInfo,
+  SurveyTemplate,
+  SurveyTemplateData,
 } from './dtos/survey-assignment.dto';
 import User from './dtos/user.dto';
 
@@ -114,6 +116,11 @@ export class ApiClient {
     return surveysSchema.parse(surveys) as Survey[];
   }
 
+  public async getMySurveyTemplates(): Promise<SurveyTemplateData[]> {
+    const surveytemplates = await this.get('/survey-template');
+    return surveytemplates as Promise<SurveyTemplateData[]>;
+  }
+
   public async completeAssignment(assignmentUuid: string, responses: Response[]): Promise<void> {
     this.post(`/assignment/${assignmentUuid}`, { responses }).catch((BadRequestException) => {
       throw BadRequestException;
@@ -141,13 +148,19 @@ export class ApiClient {
     return this.get(`/survey/${surveyUuid}/assignments`) as Promise<SurveyDetail>;
   }
 
-  public async createSurvey(surveyName: string, templateId: number): Promise<Survey> {
+  public async createSurvey(
+    name: string,
+    surveyTemplateId: number,
+    organizationName: string,
+    imageBase64: string,
+    treatmentPercentage: number,
+  ): Promise<Survey> {
     return this.post(`/survey`, {
-      name: surveyName,
-      surveyTemplateId: templateId,
-      organizationName: 'placeholder',
-      imageBase64: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg==',
-      treatmentPercentage: 50,
+      name,
+      surveyTemplateId,
+      organizationName,
+      imageBase64,
+      treatmentPercentage,
     }) as Promise<Survey>;
   }
 

--- a/src/api/dtos/survey-assignment.dto.ts
+++ b/src/api/dtos/survey-assignment.dto.ts
@@ -33,6 +33,11 @@ export interface SurveyTemplate {
   questions: Question[];
 }
 
+export interface SurveyTemplateData {
+  id: number;
+  name: string;
+}
+
 export interface Question {
   question: string;
   options: string[];

--- a/src/api/dtos/survey-assignment.dto.ts
+++ b/src/api/dtos/survey-assignment.dto.ts
@@ -38,10 +38,14 @@ export interface SurveyTemplateData {
   name: string;
 }
 
+
 export const surveyTemplateSchema = z.object({
   id: z.number(),
   name: z.string(),
 });
+
+
+export const surveyTemplatesSchema = z.array(surveyTemplateSchema);
 
 export interface Question {
   question: string;

--- a/src/api/dtos/survey-assignment.dto.ts
+++ b/src/api/dtos/survey-assignment.dto.ts
@@ -38,12 +38,10 @@ export interface SurveyTemplateData {
   name: string;
 }
 
-
 export const surveyTemplateSchema = z.object({
   id: z.number(),
   name: z.string(),
 });
-
 
 export const surveyTemplatesSchema = z.array(surveyTemplateSchema);
 

--- a/src/api/dtos/survey-assignment.dto.ts
+++ b/src/api/dtos/survey-assignment.dto.ts
@@ -38,6 +38,11 @@ export interface SurveyTemplateData {
   name: string;
 }
 
+export const surveyTemplateSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+});
+
 export interface Question {
   question: string;
   options: string[];

--- a/src/components/createSurveyPage/UploadAssignmentsForm.tsx
+++ b/src/components/createSurveyPage/UploadAssignmentsForm.tsx
@@ -121,7 +121,16 @@ const UploadAssignmentsForm: React.FC<UploadAssignmentsFormProps> = ({
     <>
       <FormControl>
         <FormLabel display="flex">
-          <b>Upload Assignments CSV: <a style={{ color: '#0080FF' }} href="https://jpal-example-csv.s3.us-east-2.amazonaws.com/example-assignment.csv" download>Example CSV</a></b>
+          <b>
+            Upload Assignments CSV:{' '}
+            <a
+              style={{ color: '#0080FF' }}
+              href="https://jpal-example-csv.s3.us-east-2.amazonaws.com/example-assignment.csv"
+              download
+            >
+              Example CSV
+            </a>
+          </b>
           <Tooltip
             label={
               <Stack>

--- a/src/components/createSurveyPage/UploadHeaderImage.tsx
+++ b/src/components/createSurveyPage/UploadHeaderImage.tsx
@@ -1,0 +1,74 @@
+import React, { useCallback } from 'react';
+import Papa from 'papaparse';
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  Table,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tooltip,
+  Tr,
+} from '@chakra-ui/react';
+import { QuestionIcon } from '@chakra-ui/icons';
+
+export type UploadStatus = { success: true } | { success: false; error: string };
+
+interface UploadHeaderImageFormProps {
+  image: string;
+  setImage: React.Dispatch<React.SetStateAction<string>>;
+  setUploadStatus: (status: UploadStatus) => void;
+}
+
+const UploadHeaderImage: React.FC<UploadHeaderImageFormProps> = ({
+  image,
+  setImage,
+  setUploadStatus,
+}) => {
+  const validateImage = useCallback((parsedData: Papa.ParseResult<unknown>): UploadStatus => {
+    // could not process image
+    if (!parsedData.meta.fields) {
+      return { success: false, error: 'Could not process image' };
+    }
+
+    return { success: true };
+  }, []);
+
+  const onFormUpload = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      if (event.target.files === null) {
+        setUploadStatus({ success: false, error: 'No image given' });
+        return;
+      }
+
+      const file = event.target.files[0];
+
+      // file does not match extension criteria
+      /*
+      if (!/\.(?:jpe?g|png|gif)$/i.test(file.name)) {
+        setUploadStatus({ success: false, error: 'Image must be jpg, jpeg, png, or gif' });
+        return;
+      }*/
+
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+    },
+    [setUploadStatus, validateCsv, setAssignments],
+  );
+
+  return (
+    <FormControl>
+      <FormLabel display="flex">
+        <b>Upload Header Image</b>
+      </FormLabel>
+      <Input type="file" accept="image/*" onChange={onFormUpload} required />
+    </FormControl>
+  );
+};
+
+export default UploadHeaderImage;

--- a/src/components/createSurveyPage/UploadRequiredFields.tsx
+++ b/src/components/createSurveyPage/UploadRequiredFields.tsx
@@ -26,7 +26,6 @@ export type UploadStatus = { success: true } | { success: false; error: string }
 
 interface UploadRequiredFieldsFormProps {
   setOrganizationName: React.Dispatch<React.SetStateAction<string>>;
-  organizationName: string;
   setSplitPercentage: React.Dispatch<React.SetStateAction<number>>;
   splitPercentage: number;
   setImage: React.Dispatch<React.SetStateAction<string>>;
@@ -37,7 +36,6 @@ interface UploadRequiredFieldsFormProps {
 
 const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
   setOrganizationName,
-  organizationName,
   setSplitPercentage,
   splitPercentage,
   setImage,
@@ -53,7 +51,7 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
         const mySurveyTemplates = await apiClient.getMySurveyTemplates();
         setSurveyTemplates(mySurveyTemplates);
       } catch (e) {
-        console.error('Failed to load survey templates: ', e);
+        setSurveyTemplateData([]);
       }
     };
 
@@ -191,7 +189,6 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
                 key={template.id}
                 onClick={() => {
                   setSurveyTemplateData(template);
-                  console.log('selected: ', template);
                 }}
               >
                 {template.name}

--- a/src/components/createSurveyPage/UploadRequiredFields.tsx
+++ b/src/components/createSurveyPage/UploadRequiredFields.tsx
@@ -1,17 +1,68 @@
-import React, { useCallback } from 'react';
-import { FormControl, FormLabel, Input } from '@chakra-ui/react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { 
+  Tooltip, 
+  Text, 
+  FormControl, 
+  FormLabel, 
+  Input, 
+  Code, 
+  Slider, 
+  Stack, 
+  useSlider, 
+  SliderTrack, 
+  SliderFilledTrack, 
+  SliderThumb,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+  Button
+} 
+from '@chakra-ui/react';
+import { QuestionIcon, ChevronDownIcon } from '@chakra-ui/icons';
+import apiClient from '../../api/apiClient';
+import { SurveyTemplateData } from '../../api/dtos/survey-assignment.dto';
 
 export type UploadStatus = { success: true } | { success: false; error: string };
 
 interface UploadRequiredFieldsFormProps {
+  setOrganizationName: React.Dispatch<React.SetStateAction<string>>;
+  organizationName: string;
+  setSplitPercentage: React.Dispatch<React.SetStateAction<number>>;
+  splitPercentage: number;
   setImage: React.Dispatch<React.SetStateAction<string>>;
   setUploadStatus: (status: UploadStatus) => void;
+  surveyTemplateData: SurveyTemplateData | null;
+  setSurveyTemplateData: React.Dispatch<React.SetStateAction<SurveyTemplateData | null>>;
 }
 
 const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
+  setOrganizationName,
+  organizationName,
+  setSplitPercentage,
+  splitPercentage,
   setImage,
   setUploadStatus,
-}) => {
+  surveyTemplateData,
+  setSurveyTemplateData
+
+}) => {  
+  const [surveyTemplates, setSurveyTemplates] = useState<SurveyTemplateData[]>([]);
+
+  useEffect(() => {
+    const fetchSurveyTemplates = async() => {
+      try {
+        const mySurveyTemplates = await apiClient.getMySurveyTemplates();
+        setSurveyTemplates(mySurveyTemplates);
+      }
+      catch (e) {
+        console.log("Failed to load survey templates: ", e.message);
+      }
+    };
+
+    fetchSurveyTemplates();
+  }, []);
+
   const onFormUpload = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
       const file = event.target.files?.[0];
@@ -23,8 +74,8 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
       }
 
       // image file does not match extension criteria
-      if (!/\.(?:jpe?g|png|gif)$/i.test(file.name)) {
-        setUploadStatus({ success: false, error: 'Image must be jpg, jpeg, png, or gif' });
+      if (!/\.(?:jpe?g|png|gif|svg)$/i.test(file.name)) {
+        setUploadStatus({ success: false, error: 'Image must be jpg, jpeg, png, svg, or gif' });
         return;
       }
 
@@ -33,7 +84,6 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
       // image file succesfully read
       reader.onload = () => {
         const base64Str = reader.result as string;
-        setImage(base64Str);
         setUploadStatus({ success: true });
       };
 
@@ -52,12 +102,94 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
   );
 
   return (
-    <FormControl>
-      <FormLabel display="flex">
-        <b>Upload Header Image</b>
-      </FormLabel>
-      <Input type="file" accept="image/*" onChange={onFormUpload} required />
-    </FormControl>
+    <div>
+      <FormControl style={{ marginBottom: '1rem' }}>
+        <FormLabel display="flex">
+          <b>Organization Name</b>
+             <Tooltip
+                label="This is the name of the organization that will be displayed to survey respondents."
+                placement="right"
+                hasArrow
+              >
+              <QuestionIcon alignSelf="center" ml={2} />
+              </Tooltip>
+        </FormLabel>
+        <Input placeholder="e.g. Accelerate Academy" onChange={(e) => setOrganizationName(e.target.value)} required />
+      </FormControl>
+      <FormControl  style={{ marginBottom: '1rem' }}>
+        <FormLabel display="flex">
+          <b>Upload Header Image</b>
+          <Tooltip
+            label="This is the logo of the organization that will be displayed to survey respondents."
+            placement="right"
+            hasArrow
+          >
+          <QuestionIcon alignSelf="center" ml={2} />
+          </Tooltip>
+        </FormLabel>
+        <Input type="file" accept="image/*" onChange={onFormUpload} required />
+      </FormControl>
+      <FormControl style={{ marginBottom: '1rem' }}>
+        <FormLabel display="flex">
+          <b>Input Split Percentage</b>
+          <Tooltip
+            label="This is the percentage of youth that will receive letters (percentage in treatment group)."
+            placement="right"
+            hasArrow
+          >
+          <QuestionIcon alignSelf="center" ml={2} />
+          </Tooltip>
+        </FormLabel>
+            <Stack align="flex-start">
+              <div style={{alignItems: "center", display: "flex", flexDirection: 'column'}}>
+              <Slider
+                aria-label="split-percentage-slider"
+                value={splitPercentage}
+                onChange={(e) => setSplitPercentage(e)}
+                min={0}
+                max={100}
+                width="300px"
+              >
+                <SliderTrack>
+                  <SliderFilledTrack />
+                </SliderTrack>
+                <SliderThumb />
+              </Slider>
+              <Code style={{backgroundColor: 'transparent', fontFamily: 'Inter', fontWeight: 'bold', color: '#4A90E2'}}>
+                {splitPercentage}%
+                </Code>
+              </div>
+            </Stack>
+      </FormControl>
+      <FormControl  style={{ marginBottom: '1rem' }}>
+        <FormLabel display="flex">
+          <b>Survey Template</b>
+          <Tooltip
+            label="This is the survey template with the questions that will be given to participants."
+            placement="right"
+            hasArrow
+          >
+          <QuestionIcon alignSelf="center" ml={2} />
+          </Tooltip>
+        </FormLabel>
+        <Menu>
+          <MenuButton as={Button} width="200px" colorScheme="gray" rightIcon={<ChevronDownIcon  />}>
+            {surveyTemplateData ? surveyTemplateData.name : 'Select a template'} 
+          </MenuButton>
+          <MenuList>
+            {surveyTemplates.map((template: SurveyTemplateData) => (
+              <MenuItem
+                key={template.id}
+                onClick={() => setSurveyTemplateData(template)}
+              >
+                {template.name}
+              </MenuItem>
+            ))}
+          </MenuList>
+        </Menu>
+      </FormControl>
+
+    </div>
   );
 };
 

--- a/src/components/createSurveyPage/UploadRequiredFields.tsx
+++ b/src/components/createSurveyPage/UploadRequiredFields.tsx
@@ -1,24 +1,23 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { 
-  Tooltip, 
-  Text, 
-  FormControl, 
-  FormLabel, 
-  Input, 
-  Code, 
-  Slider, 
-  Stack, 
-  useSlider, 
-  SliderTrack, 
-  SliderFilledTrack, 
+import {
+  Tooltip,
+  Text,
+  FormControl,
+  FormLabel,
+  Input,
+  Code,
+  Slider,
+  Stack,
+  useSlider,
+  SliderTrack,
+  SliderFilledTrack,
   SliderThumb,
   Menu,
   MenuButton,
   MenuList,
   MenuItem,
-  Button
-} 
-from '@chakra-ui/react';
+  Button,
+} from '@chakra-ui/react';
 import { QuestionIcon, ChevronDownIcon } from '@chakra-ui/icons';
 import apiClient from '../../api/apiClient';
 import { SurveyTemplateData } from '../../api/dtos/survey-assignment.dto';
@@ -44,19 +43,17 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
   setImage,
   setUploadStatus,
   surveyTemplateData,
-  setSurveyTemplateData
-
-}) => {  
+  setSurveyTemplateData,
+}) => {
   const [surveyTemplates, setSurveyTemplates] = useState<SurveyTemplateData[]>([]);
 
   useEffect(() => {
-    const fetchSurveyTemplates = async() => {
+    const fetchSurveyTemplates = async () => {
       try {
         const mySurveyTemplates = await apiClient.getMySurveyTemplates();
         setSurveyTemplates(mySurveyTemplates);
-      }
-      catch (e) {
-        console.log("Failed to load survey templates: ", e.message);
+      } catch (e) {
+        console.error('Failed to load survey templates: ', e);
       }
     };
 
@@ -84,6 +81,7 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
       // image file succesfully read
       reader.onload = () => {
         const base64Str = reader.result as string;
+        setImage(base64Str);
         setUploadStatus({ success: true });
       };
 
@@ -106,17 +104,21 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
       <FormControl style={{ marginBottom: '1rem' }}>
         <FormLabel display="flex">
           <b>Organization Name</b>
-             <Tooltip
-                label="This is the name of the organization that will be displayed to survey respondents."
-                placement="right"
-                hasArrow
-              >
-              <QuestionIcon alignSelf="center" ml={2} />
-              </Tooltip>
+          <Tooltip
+            label="This is the name of the organization that will be displayed to survey respondents."
+            placement="right"
+            hasArrow
+          >
+            <QuestionIcon alignSelf="center" ml={2} />
+          </Tooltip>
         </FormLabel>
-        <Input placeholder="e.g. Accelerate Academy" onChange={(e) => setOrganizationName(e.target.value)} required />
+        <Input
+          placeholder="e.g. Accelerate Academy"
+          onChange={(e) => setOrganizationName(e.target.value)}
+          required
+        />
       </FormControl>
-      <FormControl  style={{ marginBottom: '1rem' }}>
+      <FormControl style={{ marginBottom: '1rem' }}>
         <FormLabel display="flex">
           <b>Upload Header Image</b>
           <Tooltip
@@ -124,7 +126,7 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
             placement="right"
             hasArrow
           >
-          <QuestionIcon alignSelf="center" ml={2} />
+            <QuestionIcon alignSelf="center" ml={2} />
           </Tooltip>
         </FormLabel>
         <Input type="file" accept="image/*" onChange={onFormUpload} required />
@@ -137,31 +139,38 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
             placement="right"
             hasArrow
           >
-          <QuestionIcon alignSelf="center" ml={2} />
+            <QuestionIcon alignSelf="center" ml={2} />
           </Tooltip>
         </FormLabel>
-            <Stack align="flex-start">
-              <div style={{alignItems: "center", display: "flex", flexDirection: 'column'}}>
-              <Slider
-                aria-label="split-percentage-slider"
-                value={splitPercentage}
-                onChange={(e) => setSplitPercentage(e)}
-                min={0}
-                max={100}
-                width="300px"
-              >
-                <SliderTrack>
-                  <SliderFilledTrack />
-                </SliderTrack>
-                <SliderThumb />
-              </Slider>
-              <Code style={{backgroundColor: 'transparent', fontFamily: 'Inter', fontWeight: 'bold', color: '#4A90E2'}}>
-                {splitPercentage}%
-                </Code>
-              </div>
-            </Stack>
+        <Stack align="flex-start">
+          <div style={{ alignItems: 'center', display: 'flex', flexDirection: 'column' }}>
+            <Slider
+              aria-label="split-percentage-slider"
+              value={splitPercentage}
+              onChange={(e) => setSplitPercentage(e)}
+              min={0}
+              max={100}
+              width="300px"
+            >
+              <SliderTrack>
+                <SliderFilledTrack />
+              </SliderTrack>
+              <SliderThumb />
+            </Slider>
+            <Code
+              style={{
+                backgroundColor: 'transparent',
+                fontFamily: 'Inter',
+                fontWeight: 'bold',
+                color: '#4A90E2',
+              }}
+            >
+              {splitPercentage}%
+            </Code>
+          </div>
+        </Stack>
       </FormControl>
-      <FormControl  style={{ marginBottom: '1rem' }}>
+      <FormControl style={{ marginBottom: '1rem' }}>
         <FormLabel display="flex">
           <b>Survey Template</b>
           <Tooltip
@@ -169,18 +178,21 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
             placement="right"
             hasArrow
           >
-          <QuestionIcon alignSelf="center" ml={2} />
+            <QuestionIcon alignSelf="center" ml={2} />
           </Tooltip>
         </FormLabel>
         <Menu>
-          <MenuButton as={Button} width="200px" colorScheme="gray" rightIcon={<ChevronDownIcon  />}>
-            {surveyTemplateData ? surveyTemplateData.name : 'Select a template'} 
+          <MenuButton as={Button} width="200px" colorScheme="gray" rightIcon={<ChevronDownIcon />}>
+            {surveyTemplateData ? surveyTemplateData.name : 'Select a template'}
           </MenuButton>
           <MenuList>
             {surveyTemplates.map((template: SurveyTemplateData) => (
               <MenuItem
                 key={template.id}
-                onClick={() => setSurveyTemplateData(template)}
+                onClick={() => {
+                  setSurveyTemplateData(template);
+                  console.log('selected: ', template);
+                }}
               >
                 {template.name}
               </MenuItem>
@@ -188,7 +200,6 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
           </MenuList>
         </Menu>
       </FormControl>
-
     </div>
   );
 };

--- a/src/components/createSurveyPage/UploadRequiredFields.tsx
+++ b/src/components/createSurveyPage/UploadRequiredFields.tsx
@@ -22,6 +22,17 @@ import { QuestionIcon, ChevronDownIcon } from '@chakra-ui/icons';
 import apiClient from '../../api/apiClient';
 import { SurveyTemplateData } from '../../api/dtos/survey-assignment.dto';
 
+  interface TooltipProps {
+      message: string;
+    }
+
+    const CustomTooltip: React.FC<TooltipProps> = ({ message }) => (
+      <Tooltip label={message} placement="right" hasArrow>
+        <QuestionIcon alignSelf="center" ml={2} />
+      </Tooltip>
+    );
+
+
 export type UploadStatus = { success: true } | { success: false; error: string };
 
 interface UploadRequiredFieldsFormProps {
@@ -51,7 +62,7 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
         const mySurveyTemplates = await apiClient.getMySurveyTemplates();
         setSurveyTemplates(mySurveyTemplates);
       } catch (e) {
-        setSurveyTemplateData([]);
+        setSurveyTemplateData(null);
       }
     };
 
@@ -79,8 +90,33 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
       // image file succesfully read
       reader.onload = () => {
         const base64Str = reader.result as string;
-        setImage(base64Str);
-        setUploadStatus({ success: true });
+
+        // test image size
+        const img = new Image();
+        img.onload = () => {
+          const { width, height } = img;
+
+          // set max dimensions here
+          if (width > 500 || height > 250) {
+            setUploadStatus({
+              success: false,
+              error: `Image is too large. Maximum size is 500x250px (got ${width}x${height}).`,
+            });
+            return;
+          }
+
+          setImage(base64Str);
+          setUploadStatus({ success: true });
+        };
+
+        img.onerror = () => {
+          setUploadStatus({
+            success: false,
+            error: 'Could not load image to check dimensions.',
+          });
+        };
+
+        img.src = base64Str;
       };
 
       // handle errors
@@ -97,18 +133,13 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
     [setUploadStatus, setImage],
   );
 
+
   return (
     <div>
       <FormControl style={{ marginBottom: '1rem' }}>
         <FormLabel display="flex">
           <b>Organization Name</b>
-          <Tooltip
-            label="This is the name of the organization that will be displayed to survey respondents."
-            placement="right"
-            hasArrow
-          >
-            <QuestionIcon alignSelf="center" ml={2} />
-          </Tooltip>
+          <CustomTooltip message="This is the name of the organization that will be displayed to survey respondents." />
         </FormLabel>
         <Input
           placeholder="e.g. Accelerate Academy"
@@ -119,26 +150,14 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
       <FormControl style={{ marginBottom: '1rem' }}>
         <FormLabel display="flex">
           <b>Upload Header Image</b>
-          <Tooltip
-            label="This is the logo of the organization that will be displayed to survey respondents."
-            placement="right"
-            hasArrow
-          >
-            <QuestionIcon alignSelf="center" ml={2} />
-          </Tooltip>
+          <CustomTooltip message="This is the logo of the organization that will be displayed to survey respondents." />
         </FormLabel>
         <Input type="file" accept="image/*" onChange={onFormUpload} required />
       </FormControl>
       <FormControl style={{ marginBottom: '1rem' }}>
         <FormLabel display="flex">
           <b>Input Split Percentage</b>
-          <Tooltip
-            label="This is the percentage of youth that will receive letters (percentage in treatment group)."
-            placement="right"
-            hasArrow
-          >
-            <QuestionIcon alignSelf="center" ml={2} />
-          </Tooltip>
+          <CustomTooltip message="This is the percentage of youth that will receive letters (percentage in treatment group)."/>
         </FormLabel>
         <Stack align="flex-start">
           <div style={{ alignItems: 'center', display: 'flex', flexDirection: 'column' }}>
@@ -163,7 +182,7 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
                 color: '#4A90E2',
               }}
             >
-              {splitPercentage}%
+              {splitPercentage}% in treatment group
             </Code>
           </div>
         </Stack>
@@ -171,16 +190,10 @@ const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
       <FormControl style={{ marginBottom: '1rem' }}>
         <FormLabel display="flex">
           <b>Survey Template</b>
-          <Tooltip
-            label="This is the survey template with the questions that will be given to participants."
-            placement="right"
-            hasArrow
-          >
-            <QuestionIcon alignSelf="center" ml={2} />
-          </Tooltip>
+          <CustomTooltip message="This is the survey template with the questions that will be given to participants."/>
         </FormLabel>
         <Menu>
-          <MenuButton as={Button} width="200px" colorScheme="gray" rightIcon={<ChevronDownIcon />}>
+          <MenuButton as={Button} min-width="200px" colorScheme="gray" width="fit-content" rightIcon={<ChevronDownIcon />}>
             {surveyTemplateData ? surveyTemplateData.name : 'Select a template'}
           </MenuButton>
           <MenuList>

--- a/src/components/createSurveyPage/UploadRequiredFields.tsx
+++ b/src/components/createSurveyPage/UploadRequiredFields.tsx
@@ -1,64 +1,54 @@
 import React, { useCallback } from 'react';
-import Papa from 'papaparse';
-import {
-  Box,
-  FormControl,
-  FormLabel,
-  Input,
-  Stack,
-  Table,
-  Tbody,
-  Td,
-  Text,
-  Th,
-  Thead,
-  Tooltip,
-  Tr,
-} from '@chakra-ui/react';
-import { QuestionIcon } from '@chakra-ui/icons';
+import { FormControl, FormLabel, Input } from '@chakra-ui/react';
 
 export type UploadStatus = { success: true } | { success: false; error: string };
 
-interface UploadHeaderImageFormProps {
-  image: string;
+interface UploadRequiredFieldsFormProps {
   setImage: React.Dispatch<React.SetStateAction<string>>;
   setUploadStatus: (status: UploadStatus) => void;
 }
 
-const UploadHeaderImage: React.FC<UploadHeaderImageFormProps> = ({
-  image,
+const UploadRequiredFields: React.FC<UploadRequiredFieldsFormProps> = ({
   setImage,
   setUploadStatus,
 }) => {
-  const validateImage = useCallback((parsedData: Papa.ParseResult<unknown>): UploadStatus => {
-    // could not process image
-    if (!parsedData.meta.fields) {
-      return { success: false, error: 'Could not process image' };
-    }
-
-    return { success: true };
-  }, []);
-
   const onFormUpload = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      if (event.target.files === null) {
+      const file = event.target.files?.[0];
+
+      // no image file uploaded
+      if (file === null || file === undefined) {
         setUploadStatus({ success: false, error: 'No image given' });
         return;
       }
 
-      const file = event.target.files[0];
-
-      // file does not match extension criteria
-      /*
+      // image file does not match extension criteria
       if (!/\.(?:jpe?g|png|gif)$/i.test(file.name)) {
         setUploadStatus({ success: false, error: 'Image must be jpg, jpeg, png, or gif' });
         return;
-      }*/
+      }
 
       const reader = new FileReader();
+
+      // image file succesfully read
+      reader.onload = () => {
+        const base64Str = reader.result as string;
+        setImage(base64Str);
+        setUploadStatus({ success: true });
+      };
+
+      // handle errors
+      reader.onerror = () => {
+        setUploadStatus({
+          success: false,
+          error: 'Error while reading image file, try again with a different image.',
+        });
+      };
+
+      // read image as base64 string
       reader.readAsDataURL(file);
     },
-    [setUploadStatus, validateCsv, setAssignments],
+    [setUploadStatus, setImage],
   );
 
   return (
@@ -71,4 +61,4 @@ const UploadHeaderImage: React.FC<UploadHeaderImageFormProps> = ({
   );
 };
 
-export default UploadHeaderImage;
+export default UploadRequiredFields;

--- a/src/components/survey/ContactInfoCollect.tsx
+++ b/src/components/survey/ContactInfoCollect.tsx
@@ -73,7 +73,7 @@ const ContactInfoCollect: React.FC<ContactFormProps> = ({ onSubmit, reviewerUUID
     }
     // TODO: Send email and phone number to the backend
 
-    apiClient.updateReviewerContact(reviewerUUID, email, phoneNumber)
+    apiClient.updateReviewerContact(reviewerUUID, email, phoneNumber);
 
     onSubmit();
   };

--- a/src/components/survey/SurveyViewController.tsx
+++ b/src/components/survey/SurveyViewController.tsx
@@ -96,14 +96,13 @@ const SurveyViewController: React.FC<SurveyViewControllerProps> = ({
         <SurveyForm
           youthName={`${getCurrentYouth().firstName} ${getCurrentYouth().lastName}`}
           questions={questions}
-          continueAndSaveResponses={(responses: Response[]) =>{
+          continueAndSaveResponses={(responses: Response[]) => {
             // eslint-disable-next-line no-console
-            console.log("pressing next")
+            console.log('pressing next');
             send('CONFIRM', {
               responses,
-            })
-          }
-          }
+            });
+          }}
           goBack={() => send('REJECT')}
           savedResponses={state.context.lastSavedResponses}
         />
@@ -113,7 +112,8 @@ const SurveyViewController: React.FC<SurveyViewControllerProps> = ({
         <>
           {
             // eslint-disable-next-line no-console
-            console.log("rendering letter preview")}
+            console.log('rendering letter preview')
+          }
           <PreviewLetter
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             savedSurveyResponses={state.context.lastSavedResponses!}
@@ -127,7 +127,7 @@ const SurveyViewController: React.FC<SurveyViewControllerProps> = ({
               const youth = getCurrentYouth();
               try {
                 // eslint-disable-next-line no-console
-                console.log("submitting")
+                console.log('submitting');
                 await completeAssignment(
                   youth.assignmentUuid,
                   // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/pages/createSurveyPage/CreateSurveyPage.tsx
+++ b/src/pages/createSurveyPage/CreateSurveyPage.tsx
@@ -56,10 +56,6 @@ const CreateSurveyPage: React.FC = () => {
   const toast = useToast();
   const navigate = useNavigate();
 
-  useEffect(() => {
-    console.log(surveyTemplateData);
-  }, [surveyTemplateData]);
-
   const createSurvey = useCallback(async () => {
     let survey: Survey;
 
@@ -193,7 +189,6 @@ const CreateSurveyPage: React.FC = () => {
           <TabPanel>
             <UploadRequiredFields
               setOrganizationName={setOrganizationName}
-              organizationName={organizationName}
               setSplitPercentage={setSplitPercentage}
               splitPercentage={splitPercentage}
               setImage={setImage}

--- a/src/pages/createSurveyPage/CreateSurveyPage.tsx
+++ b/src/pages/createSurveyPage/CreateSurveyPage.tsx
@@ -16,7 +16,7 @@ import UploadAssignmentsForm, {
   AssignmentRow,
   UploadStatus,
 } from '../../components/createSurveyPage/UploadAssignmentsForm';
-import UploadHeaderImage from '../../components/createSurveyPage/UploadHeaderImage'
+import UploadRequiredFields from '../../components/createSurveyPage/UploadRequiredFields';
 import { PersonInfo, Survey } from '../../api/dtos/survey-assignment.dto';
 import apiClient from '../../api/apiClient';
 import { TOAST_POPUP_DURATION } from '../basicConstants';
@@ -43,8 +43,12 @@ export function assignmentRowToDTO(
 const CreateSurveyPage: React.FC = () => {
   const [uploadStatus, setUploadStatus] = useState<UploadStatus | null>(null);
   const [assignments, setAssignments] = useState<AssignmentRow[]>([]);
+  const [image, setImage] = useState<string>('');
+  const [organizationName, setOrganizationName] = useState<string>('');
+  const [splitPercentage, setSplitPercentage] = useState<number>(-1);
+
+  const [uploadImageStatus, setUploadImageStatus] = useState<UploadStatus | null>(null);
   const [surveyName, setSurveyName] = useState<string>('');
-  const [imageURL, setImageURL] = useState<string>('');
 
   const toast = useToast();
   const navigate = useNavigate();
@@ -109,6 +113,19 @@ const CreateSurveyPage: React.FC = () => {
     }
   }, [uploadStatus, toast]);
 
+  useEffect(() => {
+    if (uploadImageStatus !== null) {
+      toast({
+        status: uploadImageStatus.success ? 'success' : 'error',
+        description: uploadImageStatus.success
+          ? 'Image successfully uploaded'
+          : uploadImageStatus.error,
+        duration: TOAST_POPUP_DURATION,
+        isClosable: true,
+      });
+    }
+  }, [uploadImageStatus, toast]);
+
   return (
     <Container maxW="7xl">
       <Link to="/private">
@@ -137,8 +154,7 @@ const CreateSurveyPage: React.FC = () => {
             <p>TODO: display survey questions</p>
           </TabPanel> */}
           <TabPanel>
-            <UploadHeaderImage
-            image=''/>
+            <UploadRequiredFields setImage={setImage} setUploadStatus={setUploadImageStatus} />
           </TabPanel>
           <TabPanel>
             <UploadAssignmentsForm
@@ -153,7 +169,11 @@ const CreateSurveyPage: React.FC = () => {
         type="submit"
         colorScheme="teal"
         onClick={() => createSurvey()}
-        disabled={(uploadStatus !== null && !uploadStatus.success) || surveyName.length === 0}
+        disabled={
+          (uploadStatus !== null && !uploadStatus.success) ||
+          surveyName.length === 0 ||
+          (uploadImageStatus !== null && !uploadImageStatus.success)
+        }
       >
         Create Survey
       </Button>

--- a/src/pages/createSurveyPage/CreateSurveyPage.tsx
+++ b/src/pages/createSurveyPage/CreateSurveyPage.tsx
@@ -16,6 +16,7 @@ import UploadAssignmentsForm, {
   AssignmentRow,
   UploadStatus,
 } from '../../components/createSurveyPage/UploadAssignmentsForm';
+import UploadHeaderImage from '../../components/createSurveyPage/UploadHeaderImage'
 import { PersonInfo, Survey } from '../../api/dtos/survey-assignment.dto';
 import apiClient from '../../api/apiClient';
 import { TOAST_POPUP_DURATION } from '../basicConstants';
@@ -43,6 +44,7 @@ const CreateSurveyPage: React.FC = () => {
   const [uploadStatus, setUploadStatus] = useState<UploadStatus | null>(null);
   const [assignments, setAssignments] = useState<AssignmentRow[]>([]);
   const [surveyName, setSurveyName] = useState<string>('');
+  const [imageURL, setImageURL] = useState<string>('');
 
   const toast = useToast();
   const navigate = useNavigate();
@@ -127,12 +129,17 @@ const CreateSurveyPage: React.FC = () => {
       <Tabs mb={4}>
         <TabList>
           {/* <Tab>Survey Questions</Tab> */}
+          <Tab>Name, Image, Percentage (required)</Tab>
           <Tab>Upload Assignments (optional)</Tab>
         </TabList>
         <TabPanels>
           {/* <TabPanel>
             <p>TODO: display survey questions</p>
           </TabPanel> */}
+          <TabPanel>
+            <UploadHeaderImage
+            image=''/>
+          </TabPanel>
           <TabPanel>
             <UploadAssignmentsForm
               assignments={assignments}

--- a/src/pages/survey/SurveyDetailsPage.tsx
+++ b/src/pages/survey/SurveyDetailsPage.tsx
@@ -18,7 +18,7 @@ import {
   useDisclosure,
   useToast,
 } from '@chakra-ui/react';
-import { EditIcon, CheckIcon } from '@chakra-ui/icons'
+import { EditIcon, CheckIcon } from '@chakra-ui/icons';
 import apiClient, { SurveyDetail } from '../../api/apiClient';
 import LoadingSpinner from '../../components/LoadingSpinner';
 import ErrorAlert from '../../components/ErrorAlert';
@@ -32,7 +32,6 @@ import UploadAssignmentsForm, {
   UploadStatus,
 } from '../../components/createSurveyPage/UploadAssignmentsForm';
 import SurveyDetailsTable from '../../components/survey/SurveyDetailsTable';
-
 
 interface AddAssignmentsModalProps {
   isOpen: boolean;
@@ -124,7 +123,6 @@ const SurveyDetailsPage: React.FC = () => {
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const assignmentsCreateStatus = locationState![ASSIGNMENTS_CREATE_STATE_KEY]!;
 
-
     let toastMessage: string;
 
     if (assignmentsCreateStatus.success) {
@@ -178,7 +176,7 @@ const SurveyDetailsPage: React.FC = () => {
 
   const handleKeyDown = (e: any) => {
     if (e.key === 'Enter') {
-      e.preventDefault()
+      e.preventDefault();
       handleSaveName();
     }
   };
@@ -219,7 +217,7 @@ const SurveyDetailsPage: React.FC = () => {
                   onChange={(e) => setSurveyName(e.target.value)}
                 />
                 <IconButton
-                  aria-label='Edit survey'
+                  aria-label="Edit survey"
                   style={{ marginLeft: '8px' }}
                   icon={<CheckIcon />}
                   onClick={handleSaveName}
@@ -231,7 +229,7 @@ const SurveyDetailsPage: React.FC = () => {
                   {surveyName}
                 </Text>
                 <IconButton
-                  aria-label='Edit survey'
+                  aria-label="Edit survey"
                   style={{ marginLeft: '8px' }}
                   icon={<EditIcon />}
                   onClick={() => setIsEditingName(true)}

--- a/src/pages/survey/SurveyDetailsPage.tsx
+++ b/src/pages/survey/SurveyDetailsPage.tsx
@@ -201,7 +201,7 @@ const SurveyDetailsPage: React.FC = () => {
         <>
           <Heading size="lg" mb={6}>
             Survey Details for{' '}
-{isEditingName ? (
+            {isEditingName ? (
               <span>
                 <Input
                   value={surveyName}

--- a/src/pages/survey/SurveyPage.tsx
+++ b/src/pages/survey/SurveyPage.tsx
@@ -32,9 +32,9 @@ const SurveyPage: React.FC = () => {
 
   const handleCompleteAssignment = (assignmentUuid: string, responses: Response[]) => {
     // eslint-disable-next-line no-console
-    console.log("handle complete assignment!")
+    console.log('handle complete assignment!');
     return apiClient.completeAssignment(assignmentUuid, responses);
-  }
+  };
 
   return (
     <Container maxW="4xl" marginY="4">


### PR DESCRIPTION
### ℹ️ Issue

#152 

### 📝 Description

added tab with organization name, header image, split percentage, and survey template to create survey page
manual control for tabs (can only access second tab with submit button once all fields in first tab are completed, even if you go back and change fields to be empty)

### ✔️ Verification
<img width="1628" height="798" alt="image" src="https://github.com/user-attachments/assets/4db99c45-d2ad-467e-9061-81af77aa9551" />
<img width="1713" height="819" alt="image" src="https://github.com/user-attachments/assets/2a41ac12-057e-43aa-bbfb-5c6a6b780e75" />
<img width="1706" height="637" alt="image" src="https://github.com/user-attachments/assets/c2e35a12-57e5-499e-9dfa-7a535398fa23" />
<img width="1639" height="746" alt="image" src="https://github.com/user-attachments/assets/135b8b70-4a4b-49d8-9a94-97558193bb12" />
<img width="1631" height="455" alt="image" src="https://github.com/user-attachments/assets/93c03c55-524c-4785-98a2-e1de99d2b6e1" />




### 🏕️ (Optional) Future Work / Notes

should there be toast notification if survey templates are not able to be loaded from backend (for now if there is any error while fetching from backend, survey templates is just empty list but nothing is displayed to user)?